### PR TITLE
Update colophon.xhtml

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -12,7 +12,7 @@
 				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">The Story of Gösta Berling</i><br/>
-			was published in 1898 by<br/>
+			was published in 1891 by<br/>
 			<a href="https://en.wikipedia.org/wiki/Selma_Lagerl%C3%B6f">Selma Lagerlöf</a>.<br/>
 			It was translated from Swedish in 1898 by <b epub:type="z3998:personal-name">Pauline Bancroft Flach</b>.</p>
 			<p>This ebook was produced for<br/>


### PR DESCRIPTION
Changed the date of publication from 1898 to 1891. 

In the colophon (https://standardebooks.org/ebooks/selma-lagerlof/the-story-of-gosta-berling/pauline-bancroft-flach/text/colophon), it said:  The Story of Gösta Berling
was published in 1898 by
Selma Lagerlöf.
It was translated from Swedish in 1898 by Pauline Bancroft Flach.

While on Wikipedia and on the book's page itself on Standard Ebooks (https://standardebooks.org/ebooks/selma-lagerlof/the-story-of-gosta-berling/pauline-bancroft-flach), it said 'The novel was published in Swedish in 1891'.